### PR TITLE
Case insensitive paths

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ url = "https://github.com/phauer/migrate-itunes-to-rhythmbox"
 def set_properties(project):
     project.depends_on_requirements("requirements.txt")
     project.build_depends_on_requirements("requirements-build.txt")
-    project.depends_on("pyItunes", url="git+https://github.com/phauer/pyitunes.git#egg=pyItunes-1.4")  # use my fork to ensure stability
+    #project.depends_on("libpytunes", url="git+https://github.com/phauer/pyitunes.git#egg=pyItunes-1.4")  # use my fork to ensure stability
     project.set_property('distutils_classifiers', [
         'Topic :: Multimedia :: Sound/Audio :: Conversion',
         'Intended Audience :: Information Technology',

--- a/src/main/python/migrate_itunes_to_rhythmbox/common.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/common.py
@@ -1,5 +1,5 @@
 from lxml import etree
-from path import Path
+from pathlib import Path
 
 
 def get_xml_declaration(add_standalone_to_xml_declaration: bool):

--- a/src/main/python/migrate_itunes_to_rhythmbox/itunes_library_reader.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/itunes_library_reader.py
@@ -1,4 +1,4 @@
-from pyItunes import Library, Playlist, Song
+from libpytunes import Library, Playlist, Song
 from typing import List, Dict
 
 english_german_ignore_list = ("Library", "Music", "Movies", "TV Shows", "Purchased", "iTunes DJ", "Podcasts",

--- a/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_count_rating_integrator.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_count_rating_integrator.py
@@ -1,6 +1,6 @@
 from pyItunes import Song
 from typing import List, Dict
-from path import Path
+from pathlib import Path
 import lxml.etree
 from migrate_itunes_to_rhythmbox import common
 from time import struct_time

--- a/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_count_rating_integrator.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_count_rating_integrator.py
@@ -81,6 +81,9 @@ def create_itunes_statistic_dict(itunes_songs: Dict[int, Song], itunes_library_r
             last_played = itunes_song.lastplayed
             last_played_timestamp = calendar.timegm(last_played) if last_played is not None else None
             date_added = itunes_song.date_added
+            date_modified = itunes_song.date_modified
+            if date_modified < date_added:
+                date_added = date_modified #somehow I messed up the timestamps on my library back in 2011
             date_added_timestamp = calendar.timegm(date_added) if date_added is not None else None
             itunes_rating = itunes_song.rating
             mapped_rating = ITUNES_TO_RHYTHMBOX_RATINGS_MAP[itunes_rating]

--- a/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_count_rating_integrator.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_count_rating_integrator.py
@@ -11,10 +11,11 @@ ITUNES_TO_RHYTHMBOX_RATINGS_MAP = {0: 0, 20: 1, 40: 2, 60: 3, 80: 4, 100: 5, Non
 
 
 class SongStatistic:
-    def __init__(self, play_count: int, rating: int, last_played_timestamp: str):
+    def __init__(self, play_count: int, rating: int, last_played_timestamp: str, date_added_timestamp: str):
         self.play_count = play_count
         self.rating = rating
         self.last_played_timestamp = last_played_timestamp
+        self.date_added_timestamp = date_added_timestamp
 
 
 class IntegrationLog:
@@ -57,6 +58,7 @@ def integrate_statistics_into_entry(itunes_statistics, rhythmdb_song_entry):
     integrate_value_to_rhythmdb_song_entry(rhythmdb_song_entry, "play-count", itunes_statistics.play_count)
     integrate_value_to_rhythmdb_song_entry(rhythmdb_song_entry, "rating", itunes_statistics.rating)
     integrate_value_to_rhythmdb_song_entry(rhythmdb_song_entry, "last-played", itunes_statistics.last_played_timestamp)
+    integrate_value_to_rhythmdb_song_entry(rhythmdb_song_entry, "first-seen", itunes_statistics.date_added_timestamp)
 
 
 def integrate_value_to_rhythmdb_song_entry(rhythmdb_song_entry, rhythmdb_node_name, itunes_value):
@@ -78,11 +80,13 @@ def create_itunes_statistic_dict(itunes_songs: Dict[int, Song], itunes_library_r
             count = itunes_song.play_count
             last_played = itunes_song.lastplayed
             last_played_timestamp = calendar.timegm(last_played) if last_played is not None else None
+            date_added = itunes_song.date_added
+            date_added_timestamp = calendar.timegm(date_added) if date_added is not None else None
             itunes_rating = itunes_song.rating
             mapped_rating = ITUNES_TO_RHYTHMBOX_RATINGS_MAP[itunes_rating]
             location = itunes_song.location_escaped
             canonical_location = create_canonical_location_for_itunes_location(location, itunes_library_root)
-            dict[canonical_location] = SongStatistic(count, mapped_rating, last_played_timestamp)
+            dict[canonical_location] = SongStatistic(count, mapped_rating, last_played_timestamp, date_added_timestamp)
         else:
             print("   Can't assign the track [{} - {}] because there is no file location defined. It's probably a remote file."
                   .format(itunes_song.artist, itunes_song.name))

--- a/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_count_rating_integrator.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_count_rating_integrator.py
@@ -1,4 +1,4 @@
-from pyItunes import Song
+from libpytunes import Song
 from typing import List, Dict
 from pathlib import Path
 import lxml.etree

--- a/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_playlists_writer.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_playlists_writer.py
@@ -1,5 +1,5 @@
 from lxml import etree
-from pyItunes import Playlist, Song
+from libpytunes import Playlist, Song
 from typing import List, Dict
 from pathlib import Path
 from migrate_itunes_to_rhythmbox.transform import transform_to_rhythmbox_path

--- a/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_playlists_writer.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/rhythmbox_playlists_writer.py
@@ -1,7 +1,7 @@
 from lxml import etree
 from pyItunes import Playlist, Song
 from typing import List, Dict
-from path import Path
+from pathlib import Path
 from migrate_itunes_to_rhythmbox.transform import transform_to_rhythmbox_path
 from migrate_itunes_to_rhythmbox import common
 

--- a/src/main/python/migrate_itunes_to_rhythmbox/settings.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/settings.py
@@ -1,4 +1,4 @@
-from path import Path
+from pathlib import Path
 # well, not so easy to get path resolution work during test execution for both a) a single test executed via IDE and b) via pyb
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent  # climb up to project root
 TARGET_FOLDER = PROJECT_ROOT.joinpath(PROJECT_ROOT, 'target')

--- a/src/main/python/migrate_itunes_to_rhythmbox/transform.py
+++ b/src/main/python/migrate_itunes_to_rhythmbox/transform.py
@@ -1,15 +1,16 @@
 import urllib.parse
+import os
 
+# reverse engineering showed that Rhyhtmbox doesn't escape these safe characters. if escaped they wouldn't be found by rhythmbox.
+# preserve & here because it will later be escaped during xml serialization
 # \/:*?"<>| are invalid characters for file names under windows. So we don't have to worry about them.
-
+SAFE_CHARS = "/()!'*:&$=~+,"
 
 # old implementation. property location_escaped was not yet available. took some reverse engineering.
 def transform_to_rhythmbox_path_old(location: str, target_library_root: str, source_library_root: str) -> str:
     """ replaces the library root and escapes characters, but not all. prefix with 'file://'"""
     replaced_location = location.replace(source_library_root, target_library_root)
-    escaped = urllib.parse.quote(replaced_location, safe="/()!'*:&$=~+,")
-    # reverse engineering showed that Rhyhtmbox doesn't escape these safe characters. if escaped they wouldn't be found by rhythmbox.
-    # preserve & here because it will later be escaped during xml serialization
+    escaped = urllib.parse.quote(replaced_location, safe=SAFE_CHARS)
     prefixed = "file://{}".format(escaped)
     return prefixed
 
@@ -19,4 +20,65 @@ def transform_to_rhythmbox_path(location_escaped: str, target_library_root: str,
     replaced_location = location_escaped\
         .replace(source_library_root, target_library_root)\
         .replace("localhost/", "")
-    return replaced_location
+
+    # Windows does not care about casing. So shouldn't we
+    try:
+        fixed_case_location = fix_location_casing(replaced_location)
+    except ValueError:
+        print(f"  Unable to find a file at path {replaced_location}")
+        fixed_case_location = replaced_location
+
+    return fixed_case_location
+
+
+def fix_location_casing(escaped_path: str):
+    unescaped = urllib.parse.unquote(escaped_path).removeprefix("file://")
+    correct_path = match_lowercase_path(unescaped.lower())
+
+    if correct_path == unescaped:
+        return escaped_path
+
+    else:
+        print(f"  Fixed casing for {unescaped} -> {correct_path}")
+        quoted = urllib.parse.quote(correct_path, safe=SAFE_CHARS)
+        return f"file://{quoted}"
+
+
+# Taken from https://stackoverflow.com/a/39891399
+def match_lowercase_path(path):
+    # get absolute path
+    path = os.path.abspath(path)
+
+    # try it first
+    if os.path.exists(path):
+        correct_path = path
+    # no luck
+    else:
+        # works on linux, but there must be a better way
+        components = path.split('/')
+
+        # initialise answer
+        correct_path = ''
+
+        # step through
+        for c in components:
+            if os.path.isdir(correct_path + c + '/'):
+                correct_path += c +'/'
+            elif os.path.isfile(correct_path + c):
+                correct_path += c
+            else:
+                match = find_match(correct_path, c)
+                correct_path += match
+
+    return correct_path
+
+# Taken from https://stackoverflow.com/a/39891399
+def find_match(path, ext):
+    for child in os.listdir(path):
+        if child.lower() == ext:
+            if os.path.isdir(path + child):
+                return child + '/'
+            else:
+                return child
+    else:
+        raise ValueError('Could not find a path matching (case-insensitively) {}.'.format(path + ext))

--- a/src/main/scripts/migrate-itunes-to-rhythmbox
+++ b/src/main/scripts/migrate-itunes-to-rhythmbox
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from os.path import expanduser
 import click
-from path import Path
+from pathlib import Path
 from migrate_itunes_to_rhythmbox import itunes_library_reader, rhythmbox_playlists_writer, rhythmbox_count_rating_integrator, settings
 
 

--- a/src/unittest/python/rhythmbox_count_rating_integrator_tests.py
+++ b/src/unittest/python/rhythmbox_count_rating_integrator_tests.py
@@ -1,6 +1,6 @@
 import unittest
 from lxml import etree
-from path import Path
+from pathlib import Path
 from migrate_itunes_to_rhythmbox import itunes_library_reader, rhythmbox_count_rating_integrator, settings
 from migrate_itunes_to_rhythmbox.rhythmbox_count_rating_integrator import SongStatistic, IntegrationLog
 

--- a/src/unittest/python/rhythmbox_playlists_writer_tests.py
+++ b/src/unittest/python/rhythmbox_playlists_writer_tests.py
@@ -1,6 +1,6 @@
 import unittest
 
-from path import Path
+from pathlib import Path
 
 from migrate_itunes_to_rhythmbox import itunes_library_reader, rhythmbox_playlists_writer, settings
 


### PR DESCRIPTION
I'm building on #26 , and I'm adding support for "case insensitive" paths (my iTunes library was coming from Windows and its case-insensitive file system, and hence the library was happily mixing `Artist/First Song.mp3` with `artist/Second Song.mp3`.

Rhythmbox on the other hand sees this folder as two different folders, and hence your script was not able to correctly handle those.

Also, I'm sharing another commit that warns against those stupid "gray star" (automatic album ratings) ratings.